### PR TITLE
Added new /convertallbo2 command

### DIFF
--- a/plugin.yml
+++ b/plugin.yml
@@ -11,6 +11,7 @@ permissions:
     children:
       bo3tools.exportbo3: true
       bo3tools.convertbo2: true
+      bo3tools.convertallbo2: true
   bo3tools.exportbo3:
     description: Export your WorldEdit selection as a BO3.
   bo3tools.convertbo2:
@@ -25,3 +26,11 @@ commands:
     description: "Convert a BO2 object to a BO3 object."
     usage: "/<command> <bo2name>"
     permission: bo3tools.convertbo2
+  convertallbo2:
+    description: "Converts all BO2 objects in the folder to BO3 objects."
+    usage: "/<command> <GlobalObjects | WorldObjects [world=currentWorld]>"
+    permission: bo3tools.convertall
+  bo2test:
+    description: "test command"
+    usage: "/testcommand <args>"
+    permission: bo3tools.test

--- a/src/nl/rutgerkok/bo3tools/BO2ConvertCommand.java
+++ b/src/nl/rutgerkok/bo3tools/BO2ConvertCommand.java
@@ -38,30 +38,71 @@ public class BO2ConvertCommand implements CommandExecutor {
             return false;
         }
 
+        //TODO: may only look for bo2, not bo3's
         // Get and check the object
-        CustomObject object = null;
-        if (world != null) {
-            object = TerrainControl.getCustomObjectManager().getCustomObject(args[0], world);
-        } else {
-            // Player isn't in a TC world, or command is sent from the console.
-            // Search
-            // the global objects.
-            object = TerrainControl.getCustomObjectManager().getCustomObject(args[0]);
-        }
-
+        CustomObject object = getObject(world, args[0]);
+        
         if (object == null) {
-            sender.sendMessage(BaseCommand.ERROR_COLOR + "The BO2 " + args[0] + " was not found.");
+        	//check if a bo3 version of this file exists
+        	if (new File(TerrainControl.getEngine().getGlobalObjectsDirectory(), args[0] + ".bo3").exists()) {
+        		sender.sendMessage(BaseCommand.ERROR_COLOR + "Object " + args[0] + " is already a BO3.");
+        		
+        	}
+        	else {
+        		sender.sendMessage(BaseCommand.ERROR_COLOR + "The BO2 " + args[0] + " was not found.");
+        	
+        	}
             return true;
         }
         if (!(object instanceof BO2)) {
-            sender.sendMessage(BaseCommand.ERROR_COLOR + "The object " + args[0] + " is not a BO2.");
+        	//check if the object is a bo3 instead
+        	if (object instanceof BO3) {
+        		sender.sendMessage(BaseCommand.ERROR_COLOR + "Object " + args[0] + " is already a BO3.");
+        		
+        	}
+        	else {
+        		sender.sendMessage(BaseCommand.ERROR_COLOR + "The object " + args[0] + " is not a BO2.");
+        		
+        	}
             return true;
         }
 
         // Create the BO3
         BO2 bo2 = (BO2) object;
-        File bo3File = new File(TerrainControl.getEngine().getGlobalObjectsDirectory(), bo2.getName() + "-converted.bo3");
-        BO3 bo3 = new BO3(bo2.getName() + "-converted.bo3", bo3File);
+        File parentDirectory = TerrainControl.getEngine().getGlobalObjectsDirectory();
+        BO3 bo3 = convertBO2(sender, bo2, parentDirectory);
+
+        // Save the BO3
+        bo3.getSettings().writeSettingsFile(true);
+
+        // Send message
+        //Had to remove the block count here as the block list was moved to the convertBO2() method
+        sender.sendMessage(BaseCommand.MESSAGE_COLOR + "Converted " + bo2.getName()  + ".bo2 to the BO3 " + bo3.getName() + "!");
+
+        return true;
+    }
+    
+    /**
+     * Converts the given BO2 into a new BO3 object, with the author set to the
+     * senders name, or <code>"Unknown"</code> if the sender is not a player.
+     * 
+     * @param sender
+     * 			Sender of the command
+     * @param bo2
+     * 			The BO2 object to convert
+     * @param parentdirectory
+     * 			The directory of the bo2 file
+     * @return 	
+     * 			A new BO3 object
+     */
+    protected BO3 convertBO2(CommandSender sender, BO2 bo2, File parentdirectory) {
+    	if (! parentdirectory.isDirectory()) {
+    		throw new IllegalArgumentException("given parentDirectory is not a directory");
+    		
+    	}  
+    	
+        File bo3File = new File(parentdirectory, bo2.getName() + ".bo3");
+    	BO3 bo3 = new BO3(bo2.getName() + ".bo3", bo3File);
         bo3.onEnable(Collections.<String, CustomObject> emptyMap());
         BO3Config bo3Config = bo3.getSettings();
 
@@ -105,16 +146,37 @@ public class BO2ConvertCommand implements CommandExecutor {
         if (sender instanceof Player) {
             bo3Config.author = sender.getName();
         }
-
-        // Save the BO3
-        bo3.getSettings().writeSettingsFile(bo3File, true);
-
-        // Send message
-        sender.sendMessage(BaseCommand.MESSAGE_COLOR + "Converted to a new BO3 file with " + newBlocks.size() + " blocks");
-        if (sender instanceof Player) {
-            plugin.log(sender.getName() + " converted the BO2 " + bo2.getName() + " to the BO3 " + bo3.getName());
-        }
-
-        return true;
+        
+		if (sender instanceof Player) {
+			plugin.log(sender.getName() + " converted the BO2 " + bo2.getName() + " to the BO3 " + bo3.getName());
+			
+		}
+        
+        return bo3;
+    	
     }
+    
+    /**
+     * Looks for the object with the given name in the given world's 
+     * WorldObjects folder or in Global objects if no world is specified.
+     * 
+     * @param world
+     * @param name
+     * @return
+     */
+    protected CustomObject getObject(LocalWorld world, String name) {
+    	CustomObject object = null;
+    	if (world != null) {
+            object = TerrainControl.getCustomObjectManager().getCustomObject(name, world);
+        } else {
+            // Player isn't in a TC world, or command is sent from the console.
+            // Search the global objects.
+            object = TerrainControl.getCustomObjectManager().getCustomObject(name);
+            
+        }
+    	
+    	return object;
+    	
+    }
+    
 }

--- a/src/nl/rutgerkok/bo3tools/BO2ConvertFolderCommand.java
+++ b/src/nl/rutgerkok/bo3tools/BO2ConvertFolderCommand.java
@@ -1,0 +1,272 @@
+package nl.rutgerkok.bo3tools;
+
+import java.io.File;
+import java.util.ArrayList;
+
+import org.bukkit.command.Command;
+import org.bukkit.command.CommandExecutor;
+import org.bukkit.command.CommandSender;
+import org.bukkit.entity.Player;
+
+import com.khorn.terraincontrol.LocalWorld;
+import com.khorn.terraincontrol.TerrainControl;
+import com.khorn.terraincontrol.bukkit.commands.BaseCommand;
+import com.khorn.terraincontrol.customobjects.CustomObject;
+import com.khorn.terraincontrol.customobjects.bo2.BO2;
+import com.khorn.terraincontrol.customobjects.bo3.BO3;
+
+/**
+ * 
+ * An implementation of the BO2ConvertCommand. Instead of converting only one
+ * BO2 at a time, it converts all the BO2's in the given folder.
+ * 
+ * @author Casper van Battum (Creator13)
+ * @see BO2ConvertCommand
+ *
+ */
+public class BO2ConvertFolderCommand extends BO2ConvertCommand 
+									 implements CommandExecutor {
+	
+	public static final String NOT_BO2 = "Object was not a bo2";
+	public static final String NOT_FOUND = "BO2 was not found";
+	public static final String ERR_UNKNOWN = "Reason unknown";
+	private static final String WORLD_OBJECTS = "WorldObjects";
+	private static final String GLOBAL_OBJECTS = "GlobalObjects";
+
+	private BO3Tools plugin;
+	private ArrayList<String> convertingErrors;
+	
+	public BO2ConvertFolderCommand(BO3Tools plugin) {
+		super(plugin);
+		this.plugin = plugin;
+		this.convertingErrors = new ArrayList<String>();
+		
+	}
+	
+	@Override
+	public boolean onCommand(CommandSender sender, Command command,
+			String label, String[] args) {
+		LocalWorld world = null;
+		String customObjectFolder = "Unkown";
+		
+		//checking the args and defining the (eventual) world
+		if (args.length == 1) {
+			if (args[0].equalsIgnoreCase(WORLD_OBJECTS)) {
+				if (sender instanceof Player) {
+					//Using player's world
+					world = TerrainControl.getWorld(((Player) sender).getWorld().getName());
+					customObjectFolder = WORLD_OBJECTS;
+					
+				}
+				else {
+					//World can't be found since the sender is not a player in a world
+					sender.sendMessage(BaseCommand.ERROR_COLOR + "Define a world!");
+					return true;
+					
+				}
+				
+			}
+			else if (args[0].equalsIgnoreCase(GLOBAL_OBJECTS)) {
+				customObjectFolder = GLOBAL_OBJECTS;
+				
+			}
+			
+		}
+		else if (args.length == 2) {
+			if (args[0].equalsIgnoreCase(WORLD_OBJECTS)) {
+				world = TerrainControl.getWorld(args[1]);
+				if (world == null) {
+					//World was not found, or not a TerrainControl world
+					sender.sendMessage(BaseCommand.ERROR_COLOR + "Couldn't find world \"" + 
+							BaseCommand.VALUE_COLOR + args[1] + BaseCommand.ERROR_COLOR + "\"!");
+					return true;
+					
+				}
+				customObjectFolder = WORLD_OBJECTS;
+				
+			}
+			else {
+				//Not a valid arg
+				return false;
+				
+			}
+			
+		}
+		else {
+			//less than one or more than two args
+			return false;
+			
+		}
+		
+		//Get all the BO2's
+		File customObjectDirectory = getObjectDirectory(customObjectFolder, world);
+		CustomObject[] objects = getCustomObjects(customObjectDirectory, world);
+		
+		//Convert all BO2's
+		BO3[] convertedObjects = convertAllObjects(objects, sender, customObjectDirectory);
+		
+		//Save all BO3's
+		saveBO3s(convertedObjects);
+		
+		//Send message & errors
+		if (! convertingErrors.isEmpty()) {
+			for (String s : convertingErrors) {
+				sender.sendMessage(s);
+				
+			}
+			
+		}
+		if (convertedObjects.length == 0) {
+			sender.sendMessage(BaseCommand.MESSAGE_COLOR + "Converted no objects");
+			
+		}
+		else if (convertedObjects.length == 1) {
+			sender.sendMessage(BaseCommand.MESSAGE_COLOR + "Converted one BO2 object successfully");
+			
+		}
+		else {
+			sender.sendMessage(BaseCommand.MESSAGE_COLOR + "Converted " + convertedObjects.length + " BO2 objects successfully");
+			
+		}
+		
+		return true;
+		
+	}
+	
+	private void saveBO3s(BO3[] convertedObjects) {
+		for (BO3 bo3 : convertedObjects) {
+			bo3.getSettings().writeSettingsFile(true);
+			
+		}
+		
+	}
+
+	private BO3[] convertAllObjects(CustomObject[] objects, CommandSender sender, File objectDirectory) {
+		ArrayList<BO3> bo3List = new ArrayList<>();
+		
+		for (CustomObject obj : objects) {
+			bo3List.add(convertBO2(sender, (BO2) obj, objectDirectory));
+			
+		}
+		
+		return bo3List.toArray(new BO3[bo3List.size()]);
+		
+	}
+
+	private CustomObject[] getCustomObjects(File customObjectsDirectory, LocalWorld world) {
+		File[] files = customObjectsDirectory.listFiles();
+		ArrayList<String> filenames = new ArrayList<>();
+		
+		//Get all the bo2 filenames (without extension)
+		for (File f : files) {
+			if (f.isFile()) {
+				//if ends on .bo2 --> means it's a bo2 file. Ignoring case.
+				if (f.getName().endsWith(".bo2") 
+						|| f.getName().endsWith(".Bo2") 
+						|| f.getName().endsWith(".bO2") 
+						|| f.getName().endsWith(".BO2")) {
+					//add the filename without extension.
+					filenames.add(removeExtension(f.getName()));
+					
+				}
+				
+			}
+			
+		}
+		
+		//Load all the files as CustomObjects
+		ArrayList<CustomObject> objects = new ArrayList<>();
+		for (String f : filenames) {
+			//Will look in both WorldObjects and GlobalObjects, but it should 
+			//find everything in the WorldObjects and never come to the GlobalObjects.
+			CustomObject o = TerrainControl.getCustomObjectManager().getCustomObject(f, world);
+			if (! (o instanceof BO2)) {
+				//Object is not a BO2 object, so it won't be added to the list 
+				//with items that will be converted. Instead, an error will be 
+				//added to the error list.
+				addConvertingError(f, NOT_BO2);
+				
+			}
+			else {
+				//Object is bo2, add to list.
+				objects.add(o);
+				
+			}
+			
+		}
+		
+		return objects.toArray(new CustomObject[objects.size()]);
+		
+	}
+	
+	/**
+	 * Adds an error to the error list in the following format: <br>
+	 * <code>Error converting [object name]: [reason]</code>
+	 * 
+	 * @param f			object name
+	 * @param errType	The reason of this error: 
+	 * 				    <code>BO2ConvertFolderCommand.NOT_FOUND</code>,
+	 * 				    <code>BO2ConvertFolderCommand.NOT_BO2</code> or
+	 * 					<code>BO2ConvertFolderCommand.ERR_UNKNOWN</code>
+	 */
+	private void addConvertingError(String f, String errType) {
+		convertingErrors.add(String.format("Error while converting %s: %s", f, errType));
+		
+	}
+
+	/**
+	 * Defines the abstract path of the directory with the CustomObjects.
+	 * 
+	 * @param customObjectsFolder
+	 * @param world
+	 * @return The abstract path of the custom objects directory
+	 */
+	private File getObjectDirectory(String customObjectsFolder, LocalWorld world) {
+		if (customObjectsFolder.equalsIgnoreCase(GLOBAL_OBJECTS)) {
+			return TerrainControl.getEngine().getGlobalObjectsDirectory();
+			
+		}
+		else if (customObjectsFolder.equalsIgnoreCase(WORLD_OBJECTS)) {
+			String fs = System.getProperty("file.separator");
+			return new File("plugins" + fs + "TerrainControl" + fs + "worlds" + fs + world.getName() + fs + "WorldObjects");
+			
+		}
+		else {
+			return null;
+			
+		}
+		
+	}
+	
+	/**
+	 * Simple method that removes the extension from a filename.
+	 * 
+	 * @param filename
+	 * @return <code>filename</code> without the extension.
+	 */
+	private String removeExtension(String filename) {
+		if (! filename.contains(".")) {
+			throw new IllegalArgumentException("Not a filename");
+			
+		}
+		
+		StringBuilder sb = new StringBuilder();
+		char[] chars = filename.toCharArray();
+		
+		for (char c : chars) {
+			if (c == '.') {
+				break;
+				
+			}
+			else {
+				sb.append(c);
+				
+			}
+			
+		}
+		
+		return sb.toString();
+		
+	}
+
+}

--- a/src/nl/rutgerkok/bo3tools/BO3Creator.java
+++ b/src/nl/rutgerkok/bo3tools/BO3Creator.java
@@ -178,12 +178,12 @@ public class BO3Creator {
         bo3.getSettings().settingsMode = ConfigMode.WriteDisable;
 
         // Save the BO3
-        bo3.getSettings().writeSettingsFile(bo3File, true);
+        bo3.getSettings().writeSettingsFile(true);
 
         return bo3;
     }
 
-    private List<BlockFunction> createBlocks() {
+	private List<BlockFunction> createBlocks() {
         File tileEntitiesFolder = new File(TerrainControl.getEngine().getGlobalObjectsDirectory(), name);
         if (includeTileEntities) {
             tileEntitiesFolder.mkdirs();

--- a/src/nl/rutgerkok/bo3tools/BO3Tools.java
+++ b/src/nl/rutgerkok/bo3tools/BO3Tools.java
@@ -39,6 +39,7 @@ public class BO3Tools extends JavaPlugin {
     public void onEnable() {
         getCommand("exportbo3").setExecutor(new BO3CreateCommand(this));
         getCommand("convertbo2").setExecutor(new BO2ConvertCommand(this));
+        getCommand("convertallbo2").setExecutor(new BO2ConvertFolderCommand(this));
         getServer().getPluginManager().registerEvents(new BO3ClickHandler(this), this);
 
         // Initialize data cache


### PR DESCRIPTION
Added the /convertallbo2 command (BO2ConvertFolderCommand.java), which converts all bo2's in the given folder, and slightly changed the BO2ConvertCommand so I could use it as superclass for the BO2ConvertFolderCommand.

Compatible with TerrainControl 2.5, WorldEdit 5.5.8 and Bukkit 1.6.4-R0.1 (NOT below)

Creator13
