### PR TITLE
Updated to work with OpenTerrainGenerator version "1.12.2 - v6"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ pip-log.txt
 # Mac crap
 .DS_Store
 
+/classes/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[Home](http://dev.bukkit.org/bukkit-mods/bo3tools/) | **Source** | [Commands and permissions](http://dev.bukkit.org/bukkit-mods/bo3tools/pages/commands/) | [Changelog](http://dev.bukkit.org/bukkit-mods/bo3tools/pages/changelog/)
+[Home](http://dev.bukkit.org/projects/bo3tools) | **Source** | [Commands and permissions](https://dev.bukkit.org/projects/bo3tools/pages/commands) | [Changelog](https://dev.bukkit.org/projects/bo3tools/pages/changelog)
 
-Tools to help with the creation of BO3s. See [here](http://dev.bukkit.org/server-mods/bo3tools/) for more information. Feel free to open a pull request (I like them!), just make sure to use no tabs (use spaces!), LF line endings and try to keep your code formatting like me.
+Tools to help with the creation of BO3s. See [here](http://dev.bukkit.org/projects/bo3tools) for more information. Feel free to open a pull request (I like them!), just make sure to use no tabs (use spaces!), LF line endings and try to keep your code formatting like me.
 
 
 ## Compatibility

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Tools to help with the creation of BO3s. See [here](http://dev.bukkit.org/server
 
 ## Compatibility
 
-BO3Tools has been updated to work with OpenTerrainGenerator version "1.12.2 - v6", available on the [releases](releases) tab. It is no longer compatible with TerrainControl.
+BO3Tools has been updated to work with OpenTerrainGenerator version "1.12.2 - v6", available on the [releases](/../../releases) tab. It is no longer compatible with TerrainControl.
 
 
 ## Build Instructions
@@ -13,33 +13,33 @@ BO3Tools has been updated to work with OpenTerrainGenerator version "1.12.2 - v6
 BO3Tools depends on OpenTerrainGenerator, installed in the local Maven repository. Due to a problem with the Forge build at the time of writing, you are advised to follow the procedure below:
 
  1. Check out the OpenTerrainGenerator sources:
-    ```
+```
 git clone https://github.com/PG85/OpenTerrainGenerator
-    ```
- 1. Change into the project root directory:
-    ```
+```
+ 2. Change into the project root directory:
+```
 cd OpenTerrainGenerator
-    ```
- 1. Edit `settings.gradle` to exclude `'platforms:forge'`:
-    ```
+```
+ 3. Edit `settings.gradle` to exclude `'platforms:forge'`:
+```
 include 'common', 'platforms:bukkit', 'releases'    
 // Was: include 'common', 'platforms:bukkit', 'platforms:forge', 'releases'
-    ```
- 1. Install OpenTerrainGenerator JAR files to the local Maven respository:
-    ```
+```
+ 4. Install OpenTerrainGenerator JAR files to the local Maven respository:
+```
 ./gradlew install
-    ```
- 1. Now you are ready to build BO3Tools. Check out the sources:
-    ```
+```
+ 5. Now you are ready to build BO3Tools. Check out the sources:
+```
 cd ..
 git clone https://github.com/totemo/BO3Tools
-    ```
-  1. Change into the project root directory and build with Maven:
-    ```
+```
+ 6. Change into the project root directory and build with Maven:
+```
 cd BO3Tools
 mvn
-    ```
-    * The JAR file will be created in the `target/` sub-directory.
+```
+   * The JAR file will be created in the `target/` sub-directory.
 
  
 ## License

--- a/README.md
+++ b/README.md
@@ -2,6 +2,46 @@
 
 Tools to help with the creation of BO3s. See [here](http://dev.bukkit.org/server-mods/bo3tools/) for more information. Feel free to open a pull request (I like them!), just make sure to use no tabs (use spaces!), LF line endings and try to keep your code formatting like me.
 
+
+## Compatibility
+
+BO3Tools has been updated to work with OpenTerrainGenerator version "1.12.2 - v6", available on the [releases](releases) tab. It is no longer compatible with TerrainControl.
+
+
+## Build Instructions
+
+BO3Tools depends on OpenTerrainGenerator, installed in the local Maven repository. Due to a problem with the Forge build at the time of writing, you are advised to follow the procedure below:
+
+ 1. Check out the OpenTerrainGenerator sources:
+    ```
+git clone https://github.com/PG85/OpenTerrainGenerator
+    ```
+ 1. Change into the project root directory:
+    ```
+cd OpenTerrainGenerator
+    ```
+ 1. Edit `settings.gradle` to exclude `'platforms:forge'`:
+    ```
+include 'common', 'platforms:bukkit', 'releases'    
+// Was: include 'common', 'platforms:bukkit', 'platforms:forge', 'releases'
+    ```
+ 1. Install OpenTerrainGenerator JAR files to the local Maven respository:
+    ```
+./gradlew install
+    ```
+ 1. Now you are ready to build BO3Tools. Check out the sources:
+    ```
+cd ..
+git clone https://github.com/totemo/BO3Tools
+    ```
+  1. Change into the project root directory and build with Maven:
+    ```
+cd BO3Tools
+mvn
+    ```
+    * The JAR file will be created in the `target/` sub-directory.
+
+ 
 ## License
 
 The BSD License

--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 	<modelVersion>4.0.0</modelVersion>
 	<groupId>nl.rutgerkok.bo3tools</groupId>
 	<artifactId>BO3Tools</artifactId>
-	<version>1.6</version>
+	<version>1.7</version>
 	<name>BO3Tools</name>
 	<description>BO3s are objects used by TerrainControl. BO3Tools allows you to export your WorldEdit selection as a BO3 object. It can also convert a BO2 object to a BO3 object.</description>
 	<url>https://github.com/rutgerkok/BO3Tools</url>
@@ -17,13 +17,9 @@
 			<id>sk89q-repo</id>
 			<url>http://maven.sk89q.com/repo/</url>
 		</repository>
-		<repository>
-			<!-- For TerrainControl -->
-			<id>rutger-repo</id>
-			<url>http://www.rutgerkok.nl/repo</url>
-		</repository>
 	</repositories>
 	<build>
+		<defaultGoal>clean package</defaultGoal>
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
@@ -55,19 +51,20 @@
 		<dependency>
 			<groupId>com.sk89q</groupId>
 			<artifactId>worldedit</artifactId>
-			<version>5.5.8</version>
+			<version>6.0.0-SNAPSHOT</version>
+			<scope>provided</scope>
+		</dependency>
+		<!-- OTG dependencies installed in local Maven repository. -->
+		<dependency>
+			<groupId>com.pg85.otg</groupId>
+			<artifactId>openterraingenerator-common</artifactId>
+			<version>1.12.2 - v6</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.khorn.terraincontrol</groupId>
-			<artifactId>terraincontrol-common</artifactId>
-			<version>2.8.4-SNAPSHOT</version>
-			<scope>provided</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.khorn.terraincontrol</groupId>
-			<artifactId>terraincontrol-bukkit</artifactId>
-			<version>2.8.4-SNAPSHOT</version>
+			<groupId>com.pg85.otg</groupId>
+			<artifactId>openterraingenerator-bukkit</artifactId>
+			<version>1.12.2 - v6</version>
 			<scope>provided</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/nl/rutgerkok/bo3tools/BO2Converter.java
+++ b/src/main/java/nl/rutgerkok/bo3tools/BO2Converter.java
@@ -34,11 +34,11 @@ public class BO2Converter {
         // Convert all blocks
         List<BlockFunction> newBlocks = new ArrayList<BlockFunction>();
         for (ObjectCoordinate oldBlock : bo2.data[0]) {
-            BlockFunction newBlock = (BlockFunction) CustomObjectConfigFunction.create(bo3Config, BlockFunction.class);
-            newBlock.x = oldBlock.x;
-            newBlock.y = oldBlock.y;
-            newBlock.z = oldBlock.z;
-            newBlock.material = oldBlock.material;
+            BlockFunction newBlock = (BlockFunction) CustomObjectConfigFunction.create(bo3Config, BlockFunction.class,
+                                                                                       oldBlock.x,
+                                                                                       oldBlock.y,
+                                                                                       oldBlock.z,
+                                                                                       oldBlock.material);
             newBlocks.add(newBlock);
         }
         bo3Config.blocks[0] = newBlocks.toArray(new BlockFunction[newBlocks.size()]);

--- a/src/main/java/nl/rutgerkok/bo3tools/BO2Converter.java
+++ b/src/main/java/nl/rutgerkok/bo3tools/BO2Converter.java
@@ -5,15 +5,15 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import com.google.common.collect.Lists;
-import com.khorn.terraincontrol.configuration.WorldConfig.ConfigMode;
-import com.khorn.terraincontrol.customobjects.CustomObject;
-import com.khorn.terraincontrol.customobjects.bo2.BO2;
-import com.khorn.terraincontrol.customobjects.bo2.ObjectCoordinate;
-import com.khorn.terraincontrol.customobjects.bo3.BO3;
-import com.khorn.terraincontrol.customobjects.bo3.BO3Config;
-import com.khorn.terraincontrol.customobjects.bo3.BO3Settings.SpawnHeightEnum;
-import com.khorn.terraincontrol.customobjects.bo3.BlockFunction;
+import com.pg85.otg.configuration.CustomObjectConfigFunction;
+import com.pg85.otg.configuration.WorldConfig.ConfigMode;
+import com.pg85.otg.customobjects.CustomObject;
+import com.pg85.otg.customobjects.bo2.BO2;
+import com.pg85.otg.customobjects.bo2.ObjectCoordinate;
+import com.pg85.otg.customobjects.bo3.BO3;
+import com.pg85.otg.customobjects.bo3.BO3Config;
+import com.pg85.otg.customobjects.bo3.BO3Settings.SpawnHeightEnum;
+import com.pg85.otg.customobjects.bo3.BlockFunction;
 
 public class BO2Converter {
 
@@ -21,10 +21,8 @@ public class BO2Converter {
      * Converts the given BO2 into a new BO3 object. All blocks and most
      * settings are converted. The BO3 isn't saved.
      * 
-     * @param authorName
-     *            Name that is used in the author setting of the BO3.
-     * @param bo2
-     *            The BO2 object to convert
+     * @param authorName Name that is used in the author setting of the BO3.
+     * @param bo2 The BO2 object to convert
      * @return A new BO3 object
      */
     public static BO3 convertBO2(String authorName, BO2 bo2) {
@@ -36,8 +34,11 @@ public class BO2Converter {
         // Convert all blocks
         List<BlockFunction> newBlocks = new ArrayList<BlockFunction>();
         for (ObjectCoordinate oldBlock : bo2.data[0]) {
-            BlockFunction newBlock = new BlockFunction(bo3Config, oldBlock.x, oldBlock.y, oldBlock.z,
-                    oldBlock.material);
+            BlockFunction newBlock = (BlockFunction) CustomObjectConfigFunction.create(bo3Config, BlockFunction.class);
+            newBlock.x = oldBlock.x;
+            newBlock.y = oldBlock.y;
+            newBlock.z = oldBlock.z;
+            newBlock.material = oldBlock.material;
             newBlocks.add(newBlock);
         }
         bo3Config.blocks[0] = newBlocks.toArray(new BlockFunction[newBlocks.size()]);
@@ -60,7 +61,7 @@ public class BO2Converter {
         bo3Config.maxPercentageOutsideSourceBlock = (int) bo2.collisionPercentage;
         bo3Config.rotateRandomly = bo2.randomRotation;
         bo3Config.settingsMode = ConfigMode.WriteDisable;
-        bo3Config.excludedBiomes = Lists.newArrayList();
+        bo3Config.excludedBiomes = new ArrayList<>();
 
         return bo3;
     }

--- a/src/main/java/nl/rutgerkok/bo3tools/BO3ClickHandler.java
+++ b/src/main/java/nl/rutgerkok/bo3tools/BO3ClickHandler.java
@@ -1,7 +1,5 @@
 package nl.rutgerkok.bo3tools;
 
-import nl.rutgerkok.bo3tools.util.BlockLocation;
-
 import org.bukkit.Material;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
@@ -12,7 +10,9 @@ import org.bukkit.event.block.Action;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.inventory.ItemStack;
 
-import com.khorn.terraincontrol.bukkit.commands.BaseCommand;
+import com.pg85.otg.bukkit.commands.BaseCommand;
+
+import nl.rutgerkok.bo3tools.util.BlockLocation;
 
 public class BO3ClickHandler implements Listener {
     protected BO3Tools plugin;

--- a/src/main/java/nl/rutgerkok/bo3tools/BO3Creator.java
+++ b/src/main/java/nl/rutgerkok/bo3tools/BO3Creator.java
@@ -204,11 +204,11 @@ public class BO3Creator {
                     Block block = world.getBlockAt(x, y, z);
                     LocalMaterialData material = getMaterial(block);
                     if (includeAir || !material.isMaterial(DefaultMaterial.AIR)) {
-                        BlockFunction blockFunction = (BlockFunction) CustomObjectConfigFunction.create(null, BlockFunction.class);
-                        blockFunction.x = x - center.getX();
-                        blockFunction.y = x - center.getY();
-                        blockFunction.z = z - center.getZ();
-                        blockFunction.material = material;
+                        BlockFunction blockFunction = (BlockFunction) CustomObjectConfigFunction.create(null, BlockFunction.class,
+                                                                                                        x - center.getX(),
+                                                                                                        y - center.getY(),
+                                                                                                        z - center.getZ(),
+                                                                                                        material);
 
                         if (includeTileEntities) {
                             // Look for tile entities

--- a/src/main/java/nl/rutgerkok/bo3tools/BO3Creator.java
+++ b/src/main/java/nl/rutgerkok/bo3tools/BO3Creator.java
@@ -8,29 +8,30 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 
-import nl.rutgerkok.bo3tools.util.BlockLocation;
-
 import org.apache.commons.lang.Validate;
 import org.bukkit.Location;
 import org.bukkit.World;
 import org.bukkit.block.Block;
 import org.bukkit.entity.Player;
 
-import com.khorn.terraincontrol.LocalMaterialData;
-import com.khorn.terraincontrol.LocalWorld;
-import com.khorn.terraincontrol.TerrainControl;
-import com.khorn.terraincontrol.configuration.WorldConfig.ConfigMode;
-import com.khorn.terraincontrol.configuration.io.FileSettingsWriter;
-import com.khorn.terraincontrol.customobjects.CustomObject;
-import com.khorn.terraincontrol.customobjects.bo3.BO3;
-import com.khorn.terraincontrol.customobjects.bo3.BO3PlaceableFunction;
-import com.khorn.terraincontrol.customobjects.bo3.BlockCheck;
-import com.khorn.terraincontrol.customobjects.bo3.BlockFunction;
-import com.khorn.terraincontrol.util.MaterialSet;
-import com.khorn.terraincontrol.util.MaterialSetEntry;
-import com.khorn.terraincontrol.util.NamedBinaryTag;
-import com.khorn.terraincontrol.util.minecraftTypes.DefaultMaterial;
+import com.pg85.otg.LocalMaterialData;
+import com.pg85.otg.LocalWorld;
+import com.pg85.otg.OTG;
+import com.pg85.otg.configuration.CustomObjectConfigFunction;
+import com.pg85.otg.configuration.WorldConfig.ConfigMode;
+import com.pg85.otg.configuration.io.FileSettingsWriterOTGPlus;
+import com.pg85.otg.configuration.io.SettingsWriterOTGPlus;
+import com.pg85.otg.customobjects.CustomObject;
+import com.pg85.otg.customobjects.bo3.BO3;
+import com.pg85.otg.customobjects.bo3.BlockCheck;
+import com.pg85.otg.customobjects.bo3.BlockFunction;
+import com.pg85.otg.logging.LogMarker;
+import com.pg85.otg.util.MaterialSetEntry;
+import com.pg85.otg.util.NamedBinaryTag;
+import com.pg85.otg.util.minecraftTypes.DefaultMaterial;
 import com.sk89q.worldedit.bukkit.selections.Selection;
+
+import nl.rutgerkok.bo3tools.util.BlockLocation;
 
 /**
  * Creates a BO3 with the given parameters. Doesn't check the BO3 size. so be
@@ -38,12 +39,25 @@ import com.sk89q.worldedit.bukkit.selections.Selection;
  *
  */
 public class BO3Creator {
+    /**
+     * Save a BO3.
+     *
+     * @param bo3 the BO3.
+     */
+    public static void saveBO3(BO3 bo3) {
+        try {
+            SettingsWriterOTGPlus writer = new FileSettingsWriterOTGPlus(bo3.getSettings().getFile());
+            bo3.getSettings().write(writer, ConfigMode.WriteAll);
+        } catch (IOException ex) {
+            OTG.log(LogMarker.ERROR, "Failed to write to file {}", bo3.getSettings().getFile());
+            OTG.printStackTrace(LogMarker.ERROR, ex);
+        }
+    }
 
     /**
      * Creates a new BO3 creator.
      *
-     * @param name
-     *            Name of the BO3.
+     * @param name Name of the BO3.
      * @return The BO3Creator, for easy linking.
      */
     public static BO3Creator name(String name) {
@@ -51,7 +65,7 @@ public class BO3Creator {
         return new BO3Creator(name);
     }
 
-    private String name;
+    private final String name;
     private BlockLocation center;
     private Selection selection;
     private boolean includeAir;
@@ -69,8 +83,7 @@ public class BO3Creator {
     /**
      * Sets the author.
      *
-     * @param player
-     *            The author.
+     * @param player The author.
      * @return The BO3Creator, for easy linking.
      */
     public BO3Creator author(Player player) {
@@ -81,8 +94,7 @@ public class BO3Creator {
     /**
      * Sets the block checks to include.
      *
-     * @param locations
-     *            The locations. Can be immutable.
+     * @param locations The locations. Can be immutable.
      * @return The BO3Creator, for easy linking.
      */
     public BO3Creator blockChecks(Set<BlockLocation> locations) {
@@ -94,8 +106,7 @@ public class BO3Creator {
     /**
      * Sets the center.
      *
-     * @param location
-     *            The location of the center.
+     * @param location The location of the center.
      * @return The BO3Creator, for easy linking.
      */
     public BO3Creator center(BlockLocation location) {
@@ -114,14 +125,14 @@ public class BO3Creator {
         Validate.notNull(center, "No center given");
 
         // Create the BO3 file
-        File bo3File = new File(TerrainControl.getEngine().getGlobalObjectsDirectory(), name + ".bo3");
+        File bo3File = new File(OTG.getEngine().getGlobalObjectsDirectory(), name + ".bo3");
 
         BO3 bo3 = new BO3(this.name, bo3File);
         bo3.onEnable(Collections.<String, CustomObject> emptyMap());
 
         // Add the blocks to the BO3
-        List<BO3PlaceableFunction> blocks = createBlocks();
-        bo3.getSettings().blocks[0] = blocks.toArray(new BO3PlaceableFunction[blocks.size()]);
+        List<BlockFunction> blocks = createBlocks();
+        bo3.getSettings().blocks[0] = blocks.toArray(new BlockFunction[blocks.size()]);
 
         // Add the block checks to the BO3
         List<BlockCheck> blockChecks = createBlockChecks();
@@ -139,9 +150,7 @@ public class BO3Creator {
         // Don't save it every TC startup
         bo3.getSettings().settingsMode = ConfigMode.WriteDisable;
 
-        // Save the BO3
-        FileSettingsWriter.writeToFile(bo3.getSettings().getSettingsAsMap(), bo3.getFile(), ConfigMode.WriteAll);
-
+        saveBO3(bo3);
         return bo3;
     }
 
@@ -151,8 +160,12 @@ public class BO3Creator {
             List<BlockCheck> tcBlockChecks = new ArrayList<BlockCheck>(blockChecks.size());
             for (BlockLocation location : blockChecks) {
                 Block block = world.getBlockAt(location.getX(), location.getY(), location.getZ());
-                BlockCheck blockCheck = new BlockCheck(null, new MaterialSet(), location.getX() - center.getX(),
-                        location.getY() - center.getY(), location.getZ() - center.getZ());
+
+                BlockCheck blockCheck = (BlockCheck) CustomObjectConfigFunction.create(null, BlockCheck.class);
+                blockCheck.x = location.getX() - center.getX();
+                blockCheck.y = location.getY() - center.getY();
+                blockCheck.z = location.getZ() - center.getZ();
+
                 LocalMaterialData material = getMaterial(block);
                 if (material.rotate().equals(material)) {
                     // Data isn't used for rotation, so it's used for subdata
@@ -171,8 +184,8 @@ public class BO3Creator {
         }
     }
 
-    private List<BO3PlaceableFunction> createBlocks() {
-        File tileEntitiesFolder = new File(TerrainControl.getEngine().getGlobalObjectsDirectory(), name);
+    private List<BlockFunction> createBlocks() {
+        File tileEntitiesFolder = new File(OTG.getEngine().getGlobalObjectsDirectory(), name);
         if (includeTileEntities) {
             tileEntitiesFolder.mkdirs();
         }
@@ -183,17 +196,19 @@ public class BO3Creator {
         Location start = selection.getMinimumPoint();
         Location end = selection.getMaximumPoint();
 
-        List<BO3PlaceableFunction> blocks = new ArrayList<BO3PlaceableFunction>(
-                selection.getWidth() * selection.getHeight() * selection.getLength());
+        List<BlockFunction> blocks = new ArrayList<BlockFunction>(
+            selection.getWidth() * selection.getHeight() * selection.getLength());
         for (int x = start.getBlockX(); x <= end.getBlockX(); x++) {
             for (int y = start.getBlockY(); y <= end.getBlockY(); y++) {
                 for (int z = start.getBlockZ(); z <= end.getBlockZ(); z++) {
                     Block block = world.getBlockAt(x, y, z);
                     LocalMaterialData material = getMaterial(block);
                     if (includeAir || !material.isMaterial(DefaultMaterial.AIR)) {
-                        BlockFunction blockFunction = new BlockFunction(null,
-                                x - center.getX(), y - center.getY(), z - center.getZ(),
-                                filterMaterail(material));
+                        BlockFunction blockFunction = (BlockFunction) CustomObjectConfigFunction.create(null, BlockFunction.class);
+                        blockFunction.x = x - center.getX();
+                        blockFunction.y = x - center.getY();
+                        blockFunction.z = z - center.getZ();
+                        blockFunction.material = material;
 
                         if (includeTileEntities) {
                             // Look for tile entities
@@ -239,7 +254,7 @@ public class BO3Creator {
     }
 
     private LocalMaterialData getMaterial(Block block) {
-        return TerrainControl.toLocalMaterialData(DefaultMaterial.getMaterial(block.getType().toString()), block.getData());
+        return OTG.toLocalMaterialData(DefaultMaterial.getMaterial(block.getType().toString()), block.getData());
     }
 
     private String getTileEntityName(NamedBinaryTag tag) {
@@ -265,8 +280,7 @@ public class BO3Creator {
     /**
      * Activates tile entities.
      *
-     * @param world
-     *            The LocalWorld object, which is needed for tile entities.
+     * @param world The LocalWorld object, which is needed for tile entities.
      * @return The BO3Creator, for easy linking.
      */
     public BO3Creator includeTileEntities(LocalWorld world) {
@@ -284,8 +298,7 @@ public class BO3Creator {
     /**
      * Sets the bounds.
      *
-     * @param selection
-     *            The bounds.
+     * @param selection The bounds.
      * @return The BO3Creator, for easy linking.
      */
     public BO3Creator selection(Selection selection) {

--- a/src/main/java/nl/rutgerkok/bo3tools/command/BO2ConvertCommand.java
+++ b/src/main/java/nl/rutgerkok/bo3tools/command/BO2ConvertCommand.java
@@ -2,23 +2,22 @@ package nl.rutgerkok.bo3tools.command;
 
 import java.io.File;
 
-import nl.rutgerkok.bo3tools.BO2Converter;
-import nl.rutgerkok.bo3tools.BO3Tools;
-
 import org.bukkit.command.Command;
 import org.bukkit.command.CommandExecutor;
 import org.bukkit.command.CommandSender;
 import org.bukkit.command.ConsoleCommandSender;
 import org.bukkit.entity.Player;
 
-import com.khorn.terraincontrol.LocalWorld;
-import com.khorn.terraincontrol.TerrainControl;
-import com.khorn.terraincontrol.bukkit.commands.BaseCommand;
-import com.khorn.terraincontrol.configuration.WorldConfig.ConfigMode;
-import com.khorn.terraincontrol.configuration.io.FileSettingsWriter;
-import com.khorn.terraincontrol.customobjects.CustomObject;
-import com.khorn.terraincontrol.customobjects.bo2.BO2;
-import com.khorn.terraincontrol.customobjects.bo3.BO3;
+import com.pg85.otg.LocalWorld;
+import com.pg85.otg.OTG;
+import com.pg85.otg.bukkit.commands.BaseCommand;
+import com.pg85.otg.customobjects.CustomObject;
+import com.pg85.otg.customobjects.bo2.BO2;
+import com.pg85.otg.customobjects.bo3.BO3;
+
+import nl.rutgerkok.bo3tools.BO2Converter;
+import nl.rutgerkok.bo3tools.BO3Creator;
+import nl.rutgerkok.bo3tools.BO3Tools;
 
 public class BO2ConvertCommand implements CommandExecutor {
 
@@ -30,7 +29,7 @@ public class BO2ConvertCommand implements CommandExecutor {
 
     @Override
     public boolean onCommand(CommandSender sender, Command command, String label, String[] args) {
-        LocalWorld world = (sender instanceof Player) ? TerrainControl.getWorld(((Player) sender).getWorld().getName()) : null;
+        LocalWorld world = (sender instanceof Player) ? OTG.getWorld(((Player) sender).getWorld().getName()) : null;
 
         if (args.length != 1) {
             // Someone hasn't read the help files ;)
@@ -64,7 +63,7 @@ public class BO2ConvertCommand implements CommandExecutor {
         BO3 bo3 = BO2Converter.convertBO2(authorName, bo2);
 
         // Save the BO3
-        FileSettingsWriter.writeToFile(bo3.getSettings().getSettingsAsMap(), bo3.getFile(), ConfigMode.WriteAll);
+        BO3Creator.saveBO3(bo3);
 
         // Move old BO2
         bo2.getFile().renameTo(new File(bo2.getFile().getAbsolutePath() + ".old"));
@@ -82,25 +81,14 @@ public class BO2ConvertCommand implements CommandExecutor {
      * Looks for the object with the given name in the given world's
      * WorldObjects folder or in Global objects if no world is specified.
      *
-     * @param world
-     *            The world the object is in, or null to search only in the
-     *            global objects directory.
-     * @param name
-     *            The name of the object.
+     * @param world The world the object is in, or null to search only in the
+     *        global objects directory.
+     * @param name The name of the object.
      * @return The object, or null if not found.
      */
     protected CustomObject getObject(LocalWorld world, String name) {
-        CustomObject object = null;
-        if (world != null) {
-            object = world.getConfigs().getCustomObjects().getObjectByName(name);
-        } else {
-            // Player isn't in a TC world, or command is sent from the console.
-            // Search the global objects.
-            object = TerrainControl.getCustomObjectManager().getGlobalObjects().getObjectByName(name);
-        }
-
-        return object;
-
+        String worldName = (world != null) ? world.getName() : null;
+        return OTG.getCustomObjectManager().getGlobalObjects().getObjectByName(name, worldName);
     }
 
 }

--- a/src/main/java/nl/rutgerkok/bo3tools/command/BO2ConvertFolderCommand.java
+++ b/src/main/java/nl/rutgerkok/bo3tools/command/BO2ConvertFolderCommand.java
@@ -5,9 +5,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import nl.rutgerkok.bo3tools.BO2Converter;
-import nl.rutgerkok.bo3tools.BO3Tools;
-
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.command.Command;
@@ -17,15 +14,17 @@ import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 import org.bukkit.util.StringUtil;
 
-import com.khorn.terraincontrol.LocalWorld;
-import com.khorn.terraincontrol.TerrainControl;
-import com.khorn.terraincontrol.bukkit.commands.BaseCommand;
-import com.khorn.terraincontrol.configuration.WorldConfig.ConfigMode;
-import com.khorn.terraincontrol.configuration.io.FileSettingsWriter;
-import com.khorn.terraincontrol.customobjects.CustomObject;
-import com.khorn.terraincontrol.customobjects.CustomObjectCollection;
-import com.khorn.terraincontrol.customobjects.bo2.BO2;
-import com.khorn.terraincontrol.customobjects.bo3.BO3;
+import com.pg85.otg.LocalWorld;
+import com.pg85.otg.OTG;
+import com.pg85.otg.bukkit.commands.BaseCommand;
+import com.pg85.otg.customobjects.CustomObject;
+import com.pg85.otg.customobjects.CustomObjectCollection;
+import com.pg85.otg.customobjects.bo2.BO2;
+import com.pg85.otg.customobjects.bo3.BO3;
+
+import nl.rutgerkok.bo3tools.BO2Converter;
+import nl.rutgerkok.bo3tools.BO3Creator;
+import nl.rutgerkok.bo3tools.BO3Tools;
 
 /**
  * 
@@ -56,7 +55,7 @@ public class BO2ConvertFolderCommand implements TabExecutor {
         // Fetch world
         if (sender instanceof Player) {
             String worldName = ((Player) sender).getWorld().getName();
-            world = TerrainControl.getWorld(worldName);
+            world = OTG.getWorld(worldName);
         }
 
         // Parse arguments
@@ -65,7 +64,7 @@ public class BO2ConvertFolderCommand implements TabExecutor {
             if (arg.equalsIgnoreCase(GLOBAL)) {
                 globalObjects = true;
             } else {
-                world = TerrainControl.getWorld(arg);
+                world = OTG.getWorld(arg);
                 if (world == null) {
                     sender.sendMessage(BaseCommand.ERROR_COLOR + "World '" + arg + "' not found.");
                 }
@@ -82,14 +81,13 @@ public class BO2ConvertFolderCommand implements TabExecutor {
         }
 
         // Get and convert objects
-        CustomObjectCollection objects;
-        if (globalObjects) {
-            objects = TerrainControl.getCustomObjectManager().getGlobalObjects();
-        } else {
-            objects = world.getConfigs().getCustomObjects();
-        }
+        CustomObjectCollection objects = OTG.getCustomObjectManager().getGlobalObjects();
+        String worldName = (world != null && !globalObjects) ? world.getName() : null;
+        // NOTE: totemo: original code got objects from the world itself. That
+        // no longer exists in the OTG API.
+
         sender.sendMessage(BaseCommand.MESSAGE_COLOR + "Converting BO2s, hang on...");
-        int count = convertBO2s(BO3Tools.getAuthorName(sender), objects);
+        int count = convertBO2s(BO3Tools.getAuthorName(sender), objects, worldName);
 
         // Messages
         sender.sendMessage(BaseCommand.MESSAGE_COLOR + "Done! Converted " + count + " BO2s.");
@@ -105,24 +103,29 @@ public class BO2ConvertFolderCommand implements TabExecutor {
      * Converts all BO2s in the CustomObject collection. Ignores all other
      * objects in the list.
      * 
-     * @param author
-     *            The author that should be used for the objects.
-     * @param objects
-     *            The objects to convert.
+     * @param author The author that should be used for the objects.
+     * @param objects The objects to convert.
+     * @param worldName The name of the world whose objects are converted, or
+     *        null to convert global objects.
      * @return The number of objects that were converted.
      */
-    protected int convertBO2s(String author, CustomObjectCollection objects) {
+    protected int convertBO2s(String author, CustomObjectCollection objects, String worldName) {
         int count = 0;
 
-        for (CustomObject object : objects) {
+        // TODO: totemo: support iteration over CustomObjectCollection.
+        // CustomObjectCollection doesn't have any methods to permit iteration.
+        // I *could* hack something up with reflection.
+        // Since I have not pressing need for this command at the moment, I have
+        // left this unimplemented.
+        CustomObject[] allObjects = new CustomObject[0];
+        for (CustomObject object : allObjects) {
             if (object instanceof BO2) {
                 // Convert BO2
                 BO2 bo2 = (BO2) object;
                 BO3 bo3 = BO2Converter.convertBO2(author, bo2);
 
                 // Save BO3
-                FileSettingsWriter.writeToFile(bo3.getSettings().getSettingsAsMap(), bo3.getFile(),
-                        ConfigMode.WriteAll);
+                BO3Creator.saveBO3(bo3);
 
                 // Move old BO2
                 bo2.getFile().renameTo(new File(bo2.getFile().getAbsolutePath() + ".old"));

--- a/src/main/java/nl/rutgerkok/bo3tools/command/BO3CreateCommand.java
+++ b/src/main/java/nl/rutgerkok/bo3tools/command/BO3CreateCommand.java
@@ -4,11 +4,6 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import nl.rutgerkok.bo3tools.BO3Creator;
-import nl.rutgerkok.bo3tools.BO3Tools;
-import nl.rutgerkok.bo3tools.NextBO3Data;
-import nl.rutgerkok.bo3tools.util.InvalidBO3Exception;
-
 import org.bukkit.Bukkit;
 import org.bukkit.World;
 import org.bukkit.command.Command;
@@ -17,12 +12,17 @@ import org.bukkit.command.TabExecutor;
 import org.bukkit.entity.Player;
 
 import com.google.common.collect.Lists;
-import com.khorn.terraincontrol.LocalWorld;
-import com.khorn.terraincontrol.TerrainControl;
-import com.khorn.terraincontrol.bukkit.commands.BaseCommand;
-import com.khorn.terraincontrol.customobjects.bo3.BO3;
+import com.pg85.otg.LocalWorld;
+import com.pg85.otg.OTG;
+import com.pg85.otg.bukkit.commands.BaseCommand;
+import com.pg85.otg.customobjects.bo3.BO3;
 import com.sk89q.worldedit.bukkit.WorldEditPlugin;
 import com.sk89q.worldedit.bukkit.selections.Selection;
+
+import nl.rutgerkok.bo3tools.BO3Creator;
+import nl.rutgerkok.bo3tools.BO3Tools;
+import nl.rutgerkok.bo3tools.NextBO3Data;
+import nl.rutgerkok.bo3tools.util.InvalidBO3Exception;
 
 public class BO3CreateCommand implements TabExecutor {
     public static final List<String> AUTO_COMPLETE_OPTIONS = Lists.newArrayList("--includeair", "--includetileentities", "--noleavesfix");
@@ -31,7 +31,7 @@ public class BO3CreateCommand implements TabExecutor {
     public static final String INCLUDE_TILE_ENTITIES = AUTO_COMPLETE_OPTIONS.get(1);
     public static final String NO_LEAVES_FIX = AUTO_COMPLETE_OPTIONS.get(2);
 
-    private BO3Tools plugin;
+    private final BO3Tools plugin;
 
     public BO3CreateCommand(BO3Tools plugin) {
         this.plugin = plugin;
@@ -53,7 +53,7 @@ public class BO3CreateCommand implements TabExecutor {
         // Some variables
         Player player = (Player) sender;
         World world = player.getWorld();
-        LocalWorld worldTC = TerrainControl.getWorld(world.getName());
+        LocalWorld worldTC = OTG.getWorld(world.getName());
         String bo3Name = "we-" + args[0];
 
         // Get the selection

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -2,7 +2,7 @@ name: '${project.name}'
 main: nl.rutgerkok.bo3tools.BO3Tools
 version: '${project.version}'
 author: "Rutger Kok"
-depend: ["TerrainControl", "WorldEdit"]
+depend: ["OpenTerrainGenerator", "WorldEdit"]
 description: Bukkit plugin to help you working with the BO3 objects.
 permissions:
   bo3tools.all:


### PR DESCRIPTION
This is a best effort at making this plugin useable with the current OTG release. TerrainControl support is dropped.

The changes have been tested with the `/exportbo3` command. The BO2 commands are untested, but the code looks reasonable to me.

OTG class CustomObjectCollection no longer has public methods to support iteration over CustomObjects, so reflection is used to access the fields needed to support `/convertallbo2`.